### PR TITLE
Typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ You'll find in `/bin` a `po2json.js` converter, based on the excellent
         "language": "en",
         "plural-forms": "nplurals=2; plural=(n!=1);"
     },
-    "simple key": "It's tranlation",
-    "another with %1 parameter": "It's %1 tranlsation",
+    "simple key": "It's translation",
+    "another with %1 parameter": "It's %1 translation",
     "a key with plural": [
         "a plural form",
         "another plural form",


### PR DESCRIPTION
Tranlation -> Translation

And there is one more in the main website : 
    i18n.setLocate('fr');

     i18n.setLocale('fr');

I'm implementing the i18n of Meta-Press.es using gettext.js, thanks.